### PR TITLE
Fix a gpu memory issue occured in ResidualStack

### DIFF
--- a/wavenet/networks.py
+++ b/wavenet/networks.py
@@ -113,20 +113,9 @@ class ResidualStack(torch.nn.Module):
 
         self.layer_size = layer_size
         self.stack_size = stack_size
-
-        self.res_blocks = self.stack_res_block(res_channels, skip_channels)
-
-    @staticmethod
-    def _residual_block(res_channels, skip_channels, dilation):
-        block = ResidualBlock(res_channels, skip_channels, dilation)
-
-        if torch.cuda.device_count() > 1:
-            block = torch.nn.DataParallel(block)
-
-        if torch.cuda.is_available():
-            block.cuda()
-
-        return block
+        self.dilations = self.build_dilations()
+        self.res_blocks = torch.nn.ModuleList([ResidualBlock(res_channels, skip_channels, dilation)
+                                               for dilation in self.dilations])
 
     def build_dilations(self):
         dilations = []
@@ -138,20 +127,6 @@ class ResidualStack(torch.nn.Module):
                 dilations.append(2 ** l)
 
         return dilations
-
-    def stack_res_block(self, res_channels, skip_channels):
-        """
-        Prepare dilated convolution blocks by layer and stack size
-        :return:
-        """
-        res_blocks = []
-        dilations = self.build_dilations()
-
-        for dilation in dilations:
-            block = self._residual_block(res_channels, skip_channels, dilation)
-            res_blocks.append(block)
-
-        return res_blocks
 
     def forward(self, x, skip_size):
         """


### PR DESCRIPTION
Hi, golbin : )
In issue #6, some guys suffered from the error "RuntimeError: cuda runtime error (2) : out of memory" when stacking ResidualBlock. 
I fixed the issue by replacing the stack_residual function. 
Actually, I don't know why it works. lol

Also, I recommend running the test on the fixed code because I only tested on the extended implementation(VQ-VAE speech version).

Thanks for sharing clean code! 